### PR TITLE
Logger rename and config key rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ synclite-cli.sh
 # With explicit options
 synclite-cli.sh <path/to/db/file> \
     --device-type SQLITE \
-    --synclite-logger-config <path/to/synclite_logger.conf>
+    --synclite-logger-config <path/to/synclite.conf>
 ```
 
 ### Remote mode (via SyncLite DB)
@@ -35,7 +35,7 @@ synclite-cli.sh <path/to/db/file> \
 ```bash
 synclite-cli.sh <path/to/db/file> \
     --device-type SQLITE \
-    --synclite-logger-config <path/to/synclite_logger.conf> \
+    --synclite-logger-config <path/to/synclite.conf> \
     --server http://localhost:5555
 ```
 

--- a/client/.classpath
+++ b/client/.classpath
@@ -29,7 +29,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="C:/synclite/SyncLiteWorkspaces/SyncLiteDistributions/SyncLite/synclite-logger-java/logger/target/synclite-logger-oss.jar"/>
+	<classpathentry kind="lib" path="C:/synclite/SyncLiteWorkspaces/SyncLiteDistributions/SyncLite/synclite-logger-java/logger/target/synclite-oss.jar"/>
 	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -86,7 +86,7 @@
 
 		<dependency>
 			<groupId>io.synclite</groupId>
-			<artifactId>synclite-logger</artifactId>
+			<artifactId>synclite</artifactId>
 			<version>${synclite-logger.version}</version>
 		</dependency>
 

--- a/client/src/main/java/com/synclite/client/ConfigUtil.java
+++ b/client/src/main/java/com/synclite/client/ConfigUtil.java
@@ -19,9 +19,9 @@ final class ConfigUtil {
 		confBuilder.append(newLine);
 		confBuilder.append("#local-data-stage-directory=<path/to/local/stage/directory>");
 		confBuilder.append(newLine);
-		confBuilder.append("destination-type=FS");
+		confBuilder.append("device-stage-type=FS");
 		confBuilder.append(newLine);
-		confBuilder.append("#destination-type=<FS|MS_ONEDRIVE|GOOGLE_DRIVE|SFTP|MINIO|KAFKA|S3>");
+		confBuilder.append("#device-stage-type=<FS|MS_ONEDRIVE|GOOGLE_DRIVE|SFTP|MINIO|KAFKA|S3>");
 		confBuilder.append(newLine);
 		confBuilder.append(newLine);
 		confBuilder.append("#==============SFTP Configuration=================");
@@ -106,7 +106,7 @@ final class ConfigUtil {
 		confBuilder.append(newLine);
 
 		String confStr = confBuilder.toString();
-		Path confPath = confDir.resolve("synclite_logger.conf");
+		Path confPath = confDir.resolve("synclite.conf");
 
 		try {
 			Files.writeString(confPath, confStr);


### PR DESCRIPTION
# synclite-client — Config Key Rename

## Summary

Renames the legacy `destination-type` config key to `device-stage-type`
in the sample `synclite.conf` generated by `ConfigUtil`.

## Changes

- [client/src/main/java/com/synclite/client/ConfigUtil.java](client/src/main/java/com/synclite/client/ConfigUtil.java)
  - `destination-type=FS` → `device-stage-type=FS`.
  - Commented "valid values" hint updated to `device-stage-type=<FS|MS_ONEDRIVE|GOOGLE_DRIVE|SFTP|MINIO|KAFKA|S3>`.

## Naming & packaging refresh

Follow-on platform-wide refactor:

- Dependency `<artifactId>synclite-logger</artifactId>` updated to `synclite` (the Java logger module was renamed).
- `client/.classpath` now references `synclite-oss.jar` (was `synclite-logger-oss.jar`).
- Local `<revision>oss</revision>` property added so `mvn install` builds with the default revision without requiring `-Drevision=oss`.
- Sample config filename updated to `synclite.conf`; legacy `synclite_logger.conf` is still accepted by the runtime.

## Compatibility

No code change required for existing client deployments — the legacy
key is still accepted by `synclite-logger-java`'s
`SyncLiteOptions.normalizeStageTypeAliases`. This PR only updates the
emitted template so newly created configs use the canonical key.
